### PR TITLE
Fixed error with cancelling account. Redirects to log-in with a bye...

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,6 +38,6 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<p>Unhappy? <%= button_to "Delete my account", registration_path(resource_name), form: { data: { turbo_confirm: "Are you sure?" } }, method: :delete %>
 
 <%= link_to "Back", :back %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,14 @@
 Rails.application.routes.draw do
-  devise_for :users
   resources :friends
   get 'home/about'
+  devise_scope :user do
+    # Redirests signing out users back to sign-in
+    get "users", to: "devise/sessions#new"
+  end
+  devise_for :users
+
   root 'home#index'
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")


### PR DESCRIPTION
notification. Found more issues with Devise 4.8.1 and Ruby 7: [Cancel Account](https://github.com/heartcombo/devise/issues/5448), [data objects require "turbo-" prefixes](https://twitter.com/excid3/status/1471241559085617154), and [need to update routes](https://betterprogramming.pub/devise-auth-setup-in-rails-7-44240aaed4be).